### PR TITLE
Fix docs to explicitly name the 'image' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, load up the function into the CASA instance:
 
 ```python
 CASA <X>: execfile('path/to/keplerian_mask.py')
-     ...: Succesfully imported `make_mask`.
+     ...: Successfully imported `make_mask`.
 ```
 
 With this loaded, to make a Keplerian mask you just need to provide some simple geometrical properties of the disk:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A script to build a Keplerian mask based to be used for CLEANing or moment map a
 First, load up the function into the CASA instance:
 
 ```python
-CASA <X>: execfile(image='path/to/keplerian_mask.py')
+CASA <X>: execfile('path/to/keplerian_mask.py')
      ...: Succesfully imported `make_mask`.
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A script to build a Keplerian mask based to be used for CLEANing or moment map a
 First, load up the function into the CASA instance:
 
 ```python
-CASA <X>: execfile('path/to/keplerian_mask.py')
+CASA <X>: execfile(image='path/to/keplerian_mask.py')
      ...: Succesfully imported `make_mask`.
 ```
 
 With this loaded, to make a Keplerian mask you just need to provide some simple geometrical properties of the disk:
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -40,7 +40,7 @@ The `r_min` and `r_max` arguments allow you to tailor the masks inner and outer 
 For example, to have a ring-like mask between 0.5 and 2.5 arcseconds in (deprojected) radius:
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -55,7 +55,7 @@ CASA <X>: make_mask('image_name.image',
 The mask can be convolved to smooth out the edges and give a bit of a buffer between the mask edge and the emission edge. There are two ways this can be done, either by including a convolution with the rescaled beam with the `nbeams` parameter:
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -67,7 +67,7 @@ CASA <X>: make_mask('image_name.image',
 Or by convolving with a circular beam with a FWHM in arcseconds given by `target_res`:
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -83,7 +83,7 @@ Each one of these will use CASA's `imsmooth` task to convolve the mask. As the c
 We can also include a non-zero emission height for molecules like 12CO. This can either by specified by a constant z/r value with the `zr` argument,
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -98,7 +98,7 @@ If you want a more complex emission surface you can define a function which take
 CASA <X>: def z_func(r):
      ...:     return 0.3 * r**1.5
 
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,
@@ -116,7 +116,7 @@ With higher spatial resolutions it is possible to resolve the radially changing 
 where `dV0` and `dVq` are parameters which can control this surface. The default values are 300 m/s for `dV0` and -0.5 for `dVq`.
 
 ```python
-CASA <X>: make_mask('image_name.image',
+CASA <X>: make_mask(image='image_name.image',
      ...:           inc=30.0,
      ...:           PA=75.0,
      ...:           mstar=1.0,

--- a/keplerian_mask.py
+++ b/keplerian_mask.py
@@ -8,7 +8,7 @@ Usage
 Load up the functions.
 
 > execfile('path/to/keplerian_mask.py')
-> Succesfully imported `make_mask`.
+> Successfully imported `make_mask`.
 
 With this loaded, to make a Keplerian mask you will get,
 
@@ -23,7 +23,7 @@ Additional Parameters
 We can also include a non-zero emission height for molecules like 12CO. This
 can either by specified by a constant z/r value with the `zr` argument,
 
-> make_mask('image_name.image', inc=30.0, PA=75.0,
+> make_mask(image='image_name.image', inc=30.0, PA=75.0,
 >           mstar=1.0, dist=140.0, vlsr=5.1e3, zr=0.3)
 
 If you want a more complex emission surface you can define a function which
@@ -123,7 +123,7 @@ def _get_offsets(image, restfreqs=None):
 
 def _make_axis(header, axis_name):
     """
-    Make the requestest axis based on the provided image. Assumes that the disk
+    Make the requested axis based on the provided image. Assumes that the disk
     is centered. TODO: Check half-pixel offset.
 
     Args:
@@ -490,4 +490,4 @@ def make_mask(inc, PA, dist, mstar, vlsr, dx0=0.0, dy0=0.0, zr=0.0,
         return rms
 
 
-print('Succesfully imported `make_mask`.')
+print('Successfully imported `make_mask`.')


### PR DESCRIPTION
I noticed that the examples in the docs wouldn't run as written, since 'image' isn't the first named parameter in the function definition.  Here's a quick fix (along with fixes for a few other typos). 