### PR TITLE
Handle Stokes axis variations, FITS file input, fix some warnings

### DIFF
--- a/keplerian_mask.py
+++ b/keplerian_mask.py
@@ -297,7 +297,7 @@ def _trim_name(image):
     return image[:-1] if image[-1] == '/' else image
 
 
-def _save_as_image(image, mask, overwrite=True):
+def _save_as_image(image, mask, overwrite=True, dropdeg=True):
     """Save as an image by copying the header info from 'image'."""
     ia.open(image)
     coord_sys = ia.coordsys().torecord()
@@ -305,9 +305,9 @@ def _save_as_image(image, mask, overwrite=True):
     outfile = _trim_name(image).replace('.image', '.mask.image')
     if overwrite:
         rmtables(outfile)
-    try:
+    if dropdeg:
         ia.fromarray(pixels=np.squeeze(mask), outfile=outfile, csys=coord_sys)
-    except RuntimeError:
+    else:
         ia.fromarray(pixels=mask, outfile=outfile, csys=coord_sys)
     ia.close()
 

--- a/keplerian_mask.py
+++ b/keplerian_mask.py
@@ -307,7 +307,7 @@ def _trim_name(image):
     return image[:-1] if image[-1] == '/' else image
 
 
-def _save_as_image(image, mask, overwrite=True, dropdeg=True):
+def _save_as_image(image, mask, overwrite=True, dropstokes=True):
     """Save as an image by copying the header info from 'image'."""
     ia.open(image)
     coord_sys = ia.coordsys().torecord()
@@ -315,8 +315,9 @@ def _save_as_image(image, mask, overwrite=True, dropdeg=True):
     outfile = _mask_name(image)
     if overwrite:
         rmtables(outfile)
-    if dropdeg:
-        ia.fromarray(pixels=np.squeeze(mask), outfile=outfile, csys=coord_sys)
+    if dropstokes:
+        ia.fromarray(pixels=np.squeeze(mask, axis=2),
+                     outfile=outfile, csys=coord_sys)
     else:
         # Make sure the Stokes axis is in the same place in the input image
         # as we assumed in making the mask, and swap if not: 
@@ -497,7 +498,7 @@ def make_mask(inc, PA, dist, mstar, vlsr, dx0=0.0, dy0=0.0, zr=0.0,
     # We should drop the Stokes axis if not in original image: 
     dropstokes = 'stokes' not in map(str.lower, imhead(image)['axisnames'])    
     # Save it as a mask. Again, clunky but it works.
-    _save_as_image(image, mask, dropdeg=dropstokes)
+    _save_as_image(image, mask, dropstokes=dropstokes)
     if (nbeams is not None) or (target_res is not None):
         _convolve_image(image, _mask_name(image),
                         nbeams=nbeams, target_res=target_res)

--- a/keplerian_mask.py
+++ b/keplerian_mask.py
@@ -473,8 +473,10 @@ def make_mask(inc, PA, dist, mstar, vlsr, dx0=0.0, dy0=0.0, zr=0.0,
     if image is None:
         return np.where(mask <= tolerance, False, True)
 
+    # We should drop the Stokes axis if not in original image: 
+    dropstokes = 'stokes' not in map(str.lower, imhead(image)['axisnames'])    
     # Save it as a mask. Again, clunky but it works.
-    _save_as_image(image, mask)
+    _save_as_image(image, mask, dropdeg=dropstokes)
     if (nbeams is not None) or (target_res is not None):
         _convolve_image(image, image.replace('.image', '.mask.image'),
                         nbeams=nbeams, target_res=target_res)
@@ -484,7 +486,7 @@ def make_mask(inc, PA, dist, mstar, vlsr, dx0=0.0, dy0=0.0, zr=0.0,
     # Export as a FITS file if requested.
     if export_FITS:
         exportfits(imagename=mask, fitsimage=mask.replace('.image', '.fits'),
-                   dropstokes=True)
+                   dropstokes=dropstokes)
 
     # Estimate the RMS of the un-masked pixels.
     if estimate_rms:

--- a/keplerian_mask.py
+++ b/keplerian_mask.py
@@ -376,10 +376,11 @@ def _save_as_mask(image, tolerance=0.01):
             masked.
     """
     ia.open(image)
-    ia.calcmask('"{}" > {:.2f}'.format(image, tolerance), name='mask0')
+    # Replace the pixel values in-place in the image with 1 or 0. The
+    # 'iif' function takes a boolean arg first, then returns the second
+    # arg if true and third arg if false. 
+    ia.calc('iif("{}" > {:.2f}, 1, 0)'.format(image, tolerance), verbose=False)
     ia.done()
-    makemask(mode='copy', inpimage=image, inpmask='{}:mask0'.format(image),
-             output=image, overwrite=True)
 
 
 def make_mask(inc, PA, dist, mstar, vlsr, dx0=0.0, dy0=0.0, zr=0.0,


### PR DESCRIPTION
This pull request does several things: 

- Avoid divide-by-zero errors in calculating velocity and linewidth at the origin.  It would be good to check that the replacement values there don't cause problems elsewhere. 
- Allow FITS images as input in addition to CASA native `.image` files. 
- Handle the presence or absence of a Stokes axis in the input image a bit more flexibly.  In particular: 
  -  Drop the dummy 1D Stokes axis from output only if we added it to the input.
  - Allow the Stokes axis on input to be in either 3rd or 4th position, and write the mask accordingly. 
  - Only drop the Stokes axis and not other 1D axes if they exist.  (Not sure if this would ever happen.) 

And a few other minor things that are a bit more stylistic but which I hope will improve maintainability: 
- Put the output mask file naming into a function to avoid repeating it several places. 
- Use the variable name `mask` only for the array and not also for the filename.
- Fix a few typos in the comments.